### PR TITLE
feat: Add dependabot config for `/terraform-cloud`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,12 @@ updates:
       prefix: "ci(terraform)"
     labels:
       - "dependabot"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform-cloud"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci(terraform)"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
- Add missing dependabot configuration for `/terraform-cloud`