### PR TITLE
feat: Migrated to use `opentofu/setup-opentofu`

### DIFF
--- a/.github/workflows/opentofu-ci.yml
+++ b/.github/workflows/opentofu-ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: kislerdm/setup-opentofu@main
+      - uses: opentofu/setup-opentofu@v1.0.0
         with:
           tofu_version: 1.6.0-alpha2
           tofu_wrapper: "false"

--- a/.github/workflows/opentofu-format.yml
+++ b/.github/workflows/opentofu-format.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: kislerdm/setup-opentofu@main
+      - uses: opentofu/setup-opentofu@v1.0.0
         with:
           tofu_version: 1.6.0-alpha2
           tofu_wrapper: "false"
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: kislerdm/setup-opentofu@main
+      - uses: opentofu/setup-opentofu@v1.0.0
         with:
           tofu_version: 1.6.0-alpha2
           tofu_wrapper: "false"

--- a/.github/workflows/opentofu-tfcmt.yml
+++ b/.github/workflows/opentofu-tfcmt.yml
@@ -26,7 +26,7 @@ jobs:
           app-id: ${{ secrets.ACTIONS_PYTHON_CI_APP_ID }}
           private-key: ${{ secrets.ACTIONS_PYTHON_CI_APP_PEM_FILE }}
 
-      - uses: kislerdm/setup-opentofu@main
+      - uses: opentofu/setup-opentofu@v1.0.0
         with:
           cli_config_credentials_token: ${{ secrets.APP_TERRAFORM_IO_TOKEN }}
           tofu_version: 1.6.0-alpha2

--- a/github/nested_repos.tf
+++ b/github/nested_repos.tf
@@ -67,4 +67,8 @@ module "github_repository_toolkit" {
       protection = {}
     }
   ]
+
+  collaborators = [
+    { permission = "push", team_id = github_team.reviewers.slug },
+  ]
 }


### PR DESCRIPTION
- Replace `kislerdm/setup-opentofu@main` with `opentofu/setup-opentofu`, which is officially supported and maintained